### PR TITLE
feat: DosageMarkdown

### DIFF
--- a/common/src/main/java/io/github/jy95/fds/common/functions/DayOfWeekFormatter.java
+++ b/common/src/main/java/io/github/jy95/fds/common/functions/DayOfWeekFormatter.java
@@ -8,6 +8,8 @@ import java.util.Map;
 
 /**
  * Class to format day of week
+ *
+ * @author jy95
  */
 public final class DayOfWeekFormatter {
 
@@ -31,6 +33,7 @@ public final class DayOfWeekFormatter {
 
     /**
      * Constructor for the formatter
+     *
      * @param locale The locale to use
      */
     public DayOfWeekFormatter(Locale locale) {
@@ -41,6 +44,7 @@ public final class DayOfWeekFormatter {
 
     /**
      * Translates a single-day code into its corresponding day of the week in text.
+     *
      * @param code The <a href="https://build.fhir.org/valueset-days-of-week.html">Day Of Week</a> code to translate
      * @return the translated day of the week as a string.
      */

--- a/common/src/main/java/io/github/jy95/fds/common/functions/UnitsOfTimeFormatter.java
+++ b/common/src/main/java/io/github/jy95/fds/common/functions/UnitsOfTimeFormatter.java
@@ -10,6 +10,8 @@ import java.util.Map;
 
 /**
  * Class to format units of time
+ *
+ * @author jy95
  */
 public final class UnitsOfTimeFormatter {
 
@@ -41,6 +43,7 @@ public final class UnitsOfTimeFormatter {
 
     /**
      * Formats a time unit with a count (e.g., "3 heures", "1 minute").
+     *
      * @param locale The locale expected for the resulting text
      * @param unit The <a href="https://build.fhir.org/valueset-units-of-time.html">unit code</a>
      * @param count The quantity
@@ -56,6 +59,7 @@ public final class UnitsOfTimeFormatter {
 
     /**
      * Formats a time unit without a count (e.g., "heures", "minute").
+     *
      * @param locale The locale expected for the resulting text
      * @param unit The <a href="https://build.fhir.org/valueset-units-of-time.html">unit code</a>
      * @param count The quantity

--- a/common/src/main/java/io/github/jy95/fds/common/types/DosageMarkdown.java
+++ b/common/src/main/java/io/github/jy95/fds/common/types/DosageMarkdown.java
@@ -19,6 +19,8 @@ import java.util.stream.Stream;
  *
  * @param <A> The type of the DosageAPI used to convert dosage objects to human-readable text.
  * @param <B> The type of the dosage object read from the JSON files.
+ * @author jy95
+ * @since 1.0.5
  */
 public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
 
@@ -26,7 +28,7 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
      * Returns a list of locales for which Markdown examples will be generated.
      * The default implementation provides English, French, German, and Dutch (Belgian).
      *
-     * @return A list of {@link Locale} objects.
+     * @return A list of {@link java.util.Locale} objects.
      */
     default List<Locale> getLocales() {
         return List.of(
@@ -41,7 +43,7 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
      * Returns the path to the resources directory containing the JSON input files.
      * The default implementation assumes the JSON files are located in {@code src/site/resources/examples}.
      *
-     * @return A {@link Path} object representing the resources directory.
+     * @return A {@link java.nio.file.Path} object representing the resources directory.
      */
     default Path getResourcesDir() {
         return Paths.get("src", "site", "resources", "examples");
@@ -52,29 +54,29 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
      * All Markdown files will be placed under this directory, potentially in subdirectories
      * that mirror the input folder structure.
      *
-     * @param locale The {@link Locale} for which the base output directory is being determined.
-     * @return A {@link Path} object representing the base output directory (e.g., src/site/en/markdown/examples).
+     * @param locale The {@link java.util.Locale} for which the base output directory is being determined.
+     * @return A {@link java.nio.file.Path} object representing the base output directory (e.g., src/site/en/markdown/examples).
      */
     default Path getBaseOutputDir(Locale locale) {
         return Paths.get("src", "site", locale.toString(), "markdown", "examples");
     }
 
     /**
-     * Creates and returns a new instance of {@link DosageAPI} for the given locale.
+     * Creates and returns a new instance of {@link io.github.jy95.fds.common.types.DosageAPI} for the given locale.
      * Implementers of this interface must provide a concrete implementation for this method.
      *
-     * @param locale The {@link Locale} for which to create the {@link DosageAPI}.
-     * @return A new {@link DosageAPI} instance configured for the specified locale.
+     * @param locale The {@link java.util.Locale} for which to create the {@link io.github.jy95.fds.common.types.DosageAPI}.
+     * @return A new {@link io.github.jy95.fds.common.types.DosageAPI} instance configured for the specified locale.
      */
     A createDosageAPI(Locale locale);
 
     /**
-     * Returns a map of {@link DosageAPI} instances, keyed by {@link Locale}.
+     * Returns a map of {@link io.github.jy95.fds.common.types.DosageAPI} instances, keyed by {@link java.util.Locale}.
      * This default implementation uses {@link #getLocales()} and {@link #createDosageAPI(Locale)}
      * to build the map.
      *
-     * @return A {@link Map} where keys are {@link Locale} objects and values are
-     * {@link DosageAPI} instances configured for that locale.
+     * @return A {@link java.util.Map} where keys are {@link java.util.Locale} objects and values are
+     * {@link io.github.jy95.fds.common.types.DosageAPI} instances configured for that locale.
      */
     default Map<Locale, A> getDosageAPIs() {
         return getLocales()
@@ -88,19 +90,19 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
     /**
      * Reads a dosage object of type {@code B} from the specified JSON file.
      *
-     * @param jsonFile The {@link Path} to the JSON file containing the dosage data.
+     * @param jsonFile The {@link java.nio.file.Path} to the JSON file containing the dosage data.
      * @return The dosage object read from the JSON file.
-     * @throws IOException If an I/O error occurs while reading the file.
+     * @throws java.io.IOException If an I/O error occurs while reading the file.
      */
     List<B> getDosageFromJson(Path jsonFile) throws IOException;
 
     /**
-     * Returns a Stream of {@link Path} objects representing all JSON files
+     * Returns a Stream of {@link java.nio.file.Path} objects representing all JSON files
      * recursively found within the resources directory and its subdirectories.
      * This method can be overridden to customize how the JSON files are located.
      *
-     * @return A {@link Stream} of {@link Path} objects for the JSON files.
-     * @throws IOException If an I/O error occurs while traversing directories.
+     * @return A {@link java.util.stream.Stream} of {@link java.nio.file.Path} objects for the JSON files.
+     * @throws java.io.IOException If an I/O error occurs while traversing directories.
      */
     default Stream<Path> getJsonFiles() throws IOException {
         return Files
@@ -113,10 +115,10 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
      * This method uses {@link #getJsonFiles()} to find all JSON files
      * and then groups them by their containing folder.
      *
-     * @return A {@link Map} where keys are {@link Path} objects representing folders,
-     * and values are {@link List} of {@link Path} objects representing JSON files
+     * @return A {@link java.util.Map} where keys are {@link java.nio.file.Path} objects representing folders,
+     * and values are {@link java.util.List} of {@link java.nio.file.Path} objects representing JSON files
      * within that folder.
-     * @throws IOException If an I/O error occurs while traversing directories.
+     * @throws java.io.IOException If an I/O error occurs while traversing directories.
      */
     default Map<Path, List<Path>> getJsonFilesGroupedByFolder() throws IOException {
         try (Stream<Path> jsonFilesStream = getJsonFiles()) {
@@ -129,9 +131,9 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
      * Generates Markdown example files for all JSON files found within the subdirectories
      * of the resources directory for each of the supported locales.
      * The generated Markdown files will contain the original JSON input and the
-     * human-readable output produced by the {@link DosageAPI}.
+     * human-readable output produced by the {@link io.github.jy95.fds.common.types.DosageAPI}.
      *
-     * @throws Exception If an error occurs during file processing or API usage.
+     * @throws java.lang.Exception If an error occurs during file processing or API usage.
      */
     default void generateMarkdown() throws Exception {
         Map<Locale, A> dosageAPIs = getDosageAPIs();
@@ -163,14 +165,14 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
     /**
      * Generates the Markdown content for a specific folder and locale.
      *
-     * @param dosageApi          The {@link DosageAPI} instance configured for the specific locale.
-     * @param inputFolder        The {@link Path} to the input folder containing JSON files.
-     * @param locale             The {@link Locale} for which to generate the Markdown.
-     * @param markdownFile       The {@link Path} to the output Markdown file.
-     * @param jsonFilesToProcess The {@link List} of {@link Path} objects representing JSON files to be processed for this folder.
-     * @throws IOException          If an I/O error occurs while reading or writing files.
-     * @throws ExecutionException
-     * @throws InterruptedException
+     * @param dosageApi          The {@link io.github.jy95.fds.common.types.DosageAPI} instance configured for the specific locale.
+     * @param inputFolder        The {@link java.nio.file.Path} to the input folder containing JSON files.
+     * @param locale             The {@link java.util.Locale} for which to generate the Markdown.
+     * @param markdownFile       The {@link java.nio.file.Path} to the output Markdown file.
+     * @param jsonFilesToProcess The {@link java.util.List} of {@link java.nio.file.Path} objects representing JSON files to be processed for this folder.
+     * @throws java.io.IOException          If an I/O error occurs while reading or writing files.
+     * @throws java.util.concurrent.ExecutionException
+     * @throws java.lang.InterruptedException
      */
     private void generateMarkdownForFolderAndLocale(A dosageApi, Path inputFolder, Locale locale, Path markdownFile, List<Path> jsonFilesToProcess) throws IOException, InterruptedException, ExecutionException {
         try (BufferedWriter writer = Files.newBufferedWriter(markdownFile)) {
@@ -221,9 +223,9 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
     /**
      * Writes the Markdown header to the output file.
      *
-     * @param writer     The {@link BufferedWriter}.
+     * @param writer     The {@link java.io.BufferedWriter}.
      * @param folderName The name of the folder.
-     * @throws IOException If an I/O error occurs while writing to the file.
+     * @throws java.io.IOException If an I/O error occurs while writing to the file.
      */
     private void writeMarkdownHeader(BufferedWriter writer, String folderName) throws IOException {
         writer.write("# " + folderName + " \n\n");
@@ -232,8 +234,8 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
     /**
      * Writes the start of the Markdown table.
      *
-     * @param writer The {@link BufferedWriter}.
-     * @throws IOException If an I/O error occurs while writing to the file.
+     * @param writer The {@link java.io.BufferedWriter}.
+     * @throws java.io.IOException If an I/O error occurs while writing to the file.
      */
     private void writeMarkdownTableStart(BufferedWriter writer) throws IOException {
         writer.write("<table>\n");
@@ -250,13 +252,13 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
      * Processes a single JSON file, reads the dosage data, generates the human-readable text,
      * and writes a row to the Markdown table.
      *
-     * @param dosageApi The {@link DosageAPI} instance configured for the specific locale.
-     * @param jsonFile  The {@link Path} to the JSON file.
-     * @param locale    The {@link Locale} for which to generate the text (used for error logging if needed).
-     * @param writer    The {@link BufferedWriter}.
-     * @throws IOException          If an I/O error occurs while reading or writing files.
-     * @throws ExecutionException
-     * @throws InterruptedException
+     * @param dosageApi The {@link io.github.jy95.fds.common.types.DosageAPI} instance configured for the specific locale.
+     * @param jsonFile  The {@link java.nio.file.Path} to the JSON file.
+     * @param locale    The {@link java.util.Locale} for which to generate the text (used for error logging if needed).
+     * @param writer    The {@link java.io.BufferedWriter}.
+     * @throws java.io.IOException          If an I/O error occurs while reading or writing files.
+     * @throws java.util.concurrent.ExecutionException
+     * @throws java.lang.InterruptedException
      */
     private void processJsonFile(A dosageApi, Path jsonFile, Locale locale, BufferedWriter writer) throws IOException, InterruptedException, ExecutionException {
         try {
@@ -272,10 +274,10 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
     /**
      * Writes a single row to the Markdown table.
      *
-     * @param writer      The {@link BufferedWriter}.
+     * @param writer      The {@link java.io.BufferedWriter}.
      * @param jsonContent The escaped JSON content.
      * @param outputText  The escaped human-readable text.
-     * @throws IOException If an I/O error occurs while writing to the file.
+     * @throws java.io.IOException If an I/O error occurs while writing to the file.
      */
     private void writeMarkdownTableRow(BufferedWriter writer, String jsonContent, String outputText) throws IOException {
         writer.write("    <tr>\n");
@@ -287,8 +289,8 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
     /**
      * Writes the end of the Markdown table.
      *
-     * @param writer The {@link BufferedWriter}.
-     * @throws IOException If an I/O error occurs while writing to the file.
+     * @param writer The {@link java.io.BufferedWriter}.
+     * @throws java.io.IOException If an I/O error occurs while writing to the file.
      */
     private void writeMarkdownTableEnd(BufferedWriter writer) throws IOException {
         writer.write("  </tbody>\n");

--- a/common/src/main/java/io/github/jy95/fds/common/types/DosageMarkdown.java
+++ b/common/src/main/java/io/github/jy95/fds/common/types/DosageMarkdown.java
@@ -152,18 +152,24 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
         Map<Locale, A> dosageAPIs = getDosageAPIs();
         Map<Path, List<Path>> groupedJsonFiles = getJsonFilesGroupedByFolder();
 
-        for (Map.Entry<Path, List<Path>> entry : groupedJsonFiles.entrySet()) {
-            Path folder = entry.getKey();
-            List<Path> jsonFilesInFolder = entry.getValue();
+        for (Locale locale : getLocales()) {
+            
+            // Prepare the main folder for the locale
+            Path baseOutputDir = getBaseOutputDir(locale);
+            Files.createDirectories(baseOutputDir);
 
-            for (Locale locale : getLocales()) {
-                Path baseOutputDir = getBaseOutputDir(locale);
-                Files.createDirectories(baseOutputDir); // Ensure the base output directory exists
+            // Prepare the dosage API for the current locale
+            A dosageApiForLocale = dosageAPIs.get(locale);
 
+            // Iterate through the grouped JSON files
+            for (Map.Entry<Path, List<Path>> entry : groupedJsonFiles.entrySet()) {
+
+                Path folder = entry.getKey();
+                List<Path> jsonFilesInFolder = entry.getValue();
+
+                // Fill in the markdown file with the JSON files
                 Path markdownFile = baseOutputDir.resolve(getRelativeMarkdownFilePath(folder));
                 Files.createDirectories(markdownFile.getParent()); // Ensure parent directories for the markdown file exist
-
-                A dosageApiForLocale = dosageAPIs.get(locale);
                 generateMarkdownForFolderAndLocale(dosageApiForLocale, folder, locale, markdownFile, jsonFilesInFolder);
             }
         }

--- a/common/src/main/java/io/github/jy95/fds/common/types/DosageMarkdown.java
+++ b/common/src/main/java/io/github/jy95/fds/common/types/DosageMarkdown.java
@@ -67,9 +67,6 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
      *
      * @param folder The {@code Path} of the folder for which to determine the output name.
      * @return A {@code String} representing the name of the output folder.
-     * If the provided {@code folder} is the same as the resources directory,
-     * the output folder name will be "general". Otherwise, the output
-     * folder name will be the string representation of the path of the
      * {@code folder} relative to the resources directory.
      */
     default String getOutputName(Path folder) {
@@ -78,8 +75,8 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
 
         String outputFolderName;
         if (relativePath.toString().isEmpty()) {
-            // If the folder is the resourcesDir itself, use "general" as the output folder name
-            outputFolderName = "general";
+            // If the folder is the resourcesDir itself, use "." as the output folder name
+            outputFolderName = ".";
         } else {
             // Otherwise, use the relative path's string as the output folder name
             outputFolderName = relativePath.toString();
@@ -174,7 +171,7 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
             List<Path> jsonFilesInFolder = entry.getValue();
 
             // Determine the output folder name for the markdown file
-            String outputFolderName = folder.getFileName() != null ? folder.getFileName().toString() : "general"; // For root level files
+            String outputFolderName = folder.getFileName().toString();
 
             for (Locale locale : getLocales()) {
                 Path outputDir = getOutputDir(locale, folder); // Use the original folder path to determine output directory

--- a/common/src/main/java/io/github/jy95/fds/common/types/DosageMarkdown.java
+++ b/common/src/main/java/io/github/jy95/fds/common/types/DosageMarkdown.java
@@ -57,6 +57,22 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
      * @return A {@link Path} object representing the output directory.
      */
     default Path getOutputDir(Locale locale, Path folder) {
+        String outputFolderName = getOutputName(folder);
+        return Paths.get("src", "site", locale.toString(), "markdown", "examples", outputFolderName);
+    }
+
+    /**
+     * Determines the name of the output folder based on the provided folder path
+     * relative to the resources directory.
+     *
+     * @param folder The {@code Path} of the folder for which to determine the output name.
+     * @return A {@code String} representing the name of the output folder.
+     * If the provided {@code folder} is the same as the resources directory,
+     * the output folder name will be "general". Otherwise, the output
+     * folder name will be the string representation of the path of the
+     * {@code folder} relative to the resources directory.
+     */
+    default String getOutputName(Path folder) {
         Path resourcesDir = getResourcesDir();
         Path relativePath = resourcesDir.relativize(folder); // e.g., "conditions" or "" (empty path for root)
 
@@ -69,7 +85,7 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
             outputFolderName = relativePath.toString();
         }
 
-        return Paths.get("src", "site", locale.toString(), "markdown", "examples", outputFolderName);
+        return outputFolderName;
     }
 
     /**
@@ -167,10 +183,6 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
 
                 // Get the specific DosageAPI for the current locale from the map
                 A dosageApiForLocale = dosageAPIs.get(locale);
-                if (dosageApiForLocale == null) {
-                    System.err.println("No DosageAPI found for locale: " + locale + ". Skipping markdown generation for this locale.");
-                    continue; // Skip if no API is configured for this locale
-                }
 
                 // Generate Markdown for the current folder and locale using the grouped files
                 generateMarkdownForFolderAndLocale(dosageApiForLocale, folder, locale, markdownFile, jsonFilesInFolder);

--- a/common/src/main/java/io/github/jy95/fds/common/types/DosageMarkdown.java
+++ b/common/src/main/java/io/github/jy95/fds/common/types/DosageMarkdown.java
@@ -60,21 +60,6 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
     }
 
     /**
-     * Determines the name of the output folder based on the provided folder path
-     * relative to the resources directory. This method is primarily for internal
-     * calculation of relative paths.
-     *
-     * @param folder The {@code Path} of the folder for which to determine the output name.
-     * @return A {@code String} representing the relative path from the resources directory
-     * (e.g., "", "text", "text/nested").
-     */
-    default String getOutputName(Path folder) {
-        Path resourcesDir = getResourcesDir();
-        Path relativePath = resourcesDir.relativize(folder);
-        return relativePath.toString();
-    }
-
-    /**
      * Creates and returns a new instance of {@link DosageAPI} for the given locale.
      * Implementers of this interface must provide a concrete implementation for this method.
      *

--- a/common/src/main/java/io/github/jy95/fds/common/types/DosageMarkdown.java
+++ b/common/src/main/java/io/github/jy95/fds/common/types/DosageMarkdown.java
@@ -1,0 +1,155 @@
+package io.github.jy95.fds.common.types;
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * An interface for generating Markdown examples of dosage information.
+ * Implementations of this interface can read dosage data from JSON files
+ * and generate human-readable Markdown documentation in multiple locales.
+ *
+ * @param <A> The type of the DosageAPI used to convert dosage objects to human-readable text.
+ * @param <B> The type of the dosage object read from the JSON files.
+ */
+public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
+
+    /**
+     * Returns a list of locales for which Markdown examples will be generated.
+     * The default implementation provides English, French, German, and Dutch (Belgian).
+     *
+     * @return A list of {@link Locale} objects.
+     */
+    default List<Locale> getLocales() {
+        return List.of(
+                Locale.ENGLISH,
+                Locale.FRENCH,
+                Locale.GERMAN,
+                Locale.forLanguageTag("nl-BE")
+        );
+    }
+
+    /**
+     * Returns the path to the resources directory containing the JSON input files.
+     * The default implementation assumes the JSON files are located in {@code src/site/resources}.
+     *
+     * @return A {@link Path} object representing the resources directory.
+     */
+    default Path getResourcesDir() {
+        return Paths.get("src", "site", "resources", "examples");
+    }
+
+    /**
+     * Returns the output directory for the generated Markdown file for a specific locale and folder.
+     * The default implementation creates a directory structure like
+     * {@code src/site/{locale}/markdown/examples/{folderName}}.
+     *
+     * @param locale The {@link Locale} for which the output directory is being determined.
+     * @param folder The {@link Path} to the input folder containing the JSON file.
+     * @return A {@link Path} object representing the output directory.
+     */
+    default Path getOutputDir(Locale locale, Path folder) {
+        return Paths.get("src", "site", locale.toString(), "markdown", "examples", folder.getFileName().toString());
+    }
+
+    /**
+     * Extracts the base name of a JSON file (without the ".json" extension).
+     *
+     * @param jsonFile The {@link Path} to the JSON file.
+     * @return The base name of the file as a {@link String}.
+     */
+    default String getBaseName(Path jsonFile) {
+        return jsonFile.getFileName().toString().replace(".json", "");
+    }
+
+    /**
+     * Returns an instance of the {@link DosageAPI} that will be used to convert
+     * the dosage objects into human-readable text.
+     *
+     * @return An instance of the {@link DosageAPI}.
+     */
+    A getDosageAPI();
+
+    /**
+     * Reads a dosage object of type {@code B} from the specified JSON file.
+     *
+     * @param jsonFile The {@link Path} to the JSON file containing the dosage data.
+     * @return The dosage object read from the JSON file.
+     * @throws IOException If an I/O error occurs while reading the file.
+     */
+    List<B> getDosageFromJson(Path jsonFile) throws IOException;
+
+    /**
+     * Generates Markdown example files for all JSON files found within the subdirectories
+     * of the resources directory for each of the supported locales.
+     * The generated Markdown files will contain the original JSON input and the
+     * human-readable output produced by the {@link DosageAPI}.
+     *
+     * @throws Exception If an error occurs during file processing or API usage.
+     */
+    default void generateMarkdown() throws Exception {
+        Path resourcesDir = getResourcesDir();
+        A lib = getDosageAPI();
+
+        try (var folders = Files.list(resourcesDir).filter(Files::isDirectory)) {
+            for (Path folder : folders.collect(Collectors.toList())) {
+                for (Locale locale : getLocales()) {
+                    Path outDir = getOutputDir(locale, folder);
+                    Files.createDirectories(outDir);
+                    Path mdFile = outDir.resolve(folder.getFileName() + ".md"); // Output file named after the folder
+
+                    try (BufferedWriter writer = Files.newBufferedWriter(mdFile)) {
+                        writer.write("# " + folder.getFileName() + " \n\n");
+                        writer.write("<table>\n");
+                        writer.write("  <thead>\n");
+                        writer.write("    <tr>\n");
+                        writer.write("      <th>Dosage</th>\n");
+                        writer.write("      <th>Human readable text</th>\n");
+                        writer.write("    </tr>\n");
+                        writer.write("  </thead>\n");
+                        writer.write("  <tbody>\n");
+
+                        try (var files = Files.list(folder).filter(f -> f.toString().endsWith(".json"))) {
+                            for (Path jsonFile : files.collect(Collectors.toList())) {
+                                try {
+                                    List<B> dosages = getDosageFromJson(jsonFile);
+                                    String outputText = lib.asHumanReadableText(dosages).get();
+                                    String jsonContent = escapeHtml(Files.readString(jsonFile));
+
+                                    writer.write("    <tr>\n");
+                                    writer.write("      <td><pre><code class=\"language-json\">" +
+                                            jsonContent +
+                                            "</code></pre></td>\n");
+                                    writer.write("      <td>" + escapeHtml(outputText).replace("\n", "<br>") + "</td>\n");
+                                    writer.write("    </tr>\n");
+                                } catch (IOException e) {
+                                    System.err.println("Error reading JSON file: " + jsonFile + " - " + e.getMessage());
+                                } catch (NoSuchElementException e) {
+                                    System.err.println("Error converting dosage from file: " + jsonFile + " - " + e.getMessage());
+                                }
+                            }
+                        }
+
+                        writer.write("  </tbody>\n");
+                        writer.write("</table>\n");
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Helper method to escape HTML special characters for safe inclusion in HTML content.
+     *
+     * @param text The text to escape.
+     * @return The escaped text.
+     */
+    default String escapeHtml(String text) {
+        return text.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#039;");
+    }
+}

--- a/common/src/main/java/io/github/jy95/fds/common/types/DosageMarkdown.java
+++ b/common/src/main/java/io/github/jy95/fds/common/types/DosageMarkdown.java
@@ -211,19 +211,25 @@ public interface DosageMarkdown<A extends DosageAPI<?, B>, B> {
      * @return A {@code String} representing the relative path and filename from the base output directory.
      */
     private String getRelativeMarkdownFilePath(Path folder) {
-        Path resourcesDir = getResourcesDir();
-        Path relativePathFromResources = resourcesDir.relativize(folder); // e.g., "", "text", "text/nested"
 
-        // The filename itself is always the last segment of the input folder name + ".md"
+        // Get the resources directory and the file name for the markdown output
+        Path resourcesDir = getResourcesDir();
         String fileName = folder.getFileName().toString() + ".md";
 
-        if (relativePathFromResources.toString().isEmpty()) {
-            // If it's the root resources directory, the relative path is just the filename.
+        // Get the relative path from the resources directory to the folder
+        // e.g., "", "text", "text/nested"
+        Path relativePathFromResources = resourcesDir.relativize(folder);
+        var nameCount = relativePathFromResources.getNameCount();
+        
+        if (nameCount <= 1) {
+            // If the folder is the resources directory itself or empty, return the file name only.
             return fileName;
         } else {
-            // For subdirectories, combine the relative path (e.g., "text", "text/nested")
-            // with the filename (e.g., "text.md", "nested.md").
-            return relativePathFromResources.resolve(fileName).toString();
+            // For subdirectories, we need to combine the relative path - 1 (the folder name) with the filename.
+            return relativePathFromResources
+                .subpath(0, nameCount - 1)
+                .resolve(fileName)
+                .toString();
         }
     }
 

--- a/common/src/test/java/io/github/jy95/fds/DosageMarkdownTest.java
+++ b/common/src/test/java/io/github/jy95/fds/DosageMarkdownTest.java
@@ -1,0 +1,96 @@
+package io.github.jy95.fds;
+
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+import io.github.jy95.fds.common.types.DosageMarkdown;
+import io.github.jy95.fds.common.types.Translator;
+import io.github.jy95.fds.common.types.DisplayOrder;
+import io.github.jy95.fds.common.types.DosageAPI;
+import io.github.jy95.fds.common.config.FDSConfig;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DosageMarkdownTest {
+    
+    // Dummy implementation of DosageAPI with string as dosage type
+    private static class DummyDosageAPI extends DosageAPI<FDSConfig, String> {
+
+        public DummyDosageAPI() {
+            super(FDSConfig.builder().build());
+        }
+
+        @Override
+        public Translator<FDSConfig, String> getTranslator(DisplayOrder displayOrder) {
+            return (dosage) -> CompletableFuture.completedFuture(dosage);
+        }
+
+        @Override
+        public boolean containsOnlySequentialInstructions(List<String> dosages) {
+            return true;
+        }
+
+        @Override
+        protected List<List<String>> groupBySequence(List<String> dosages) {
+            return Collections.singletonList(dosages);
+        }
+    }
+
+    private static class DummyMarkdown implements DosageMarkdown<DummyDosageAPI, String> {
+
+        @Override
+        public DummyDosageAPI createDosageAPI(Locale locale) {
+            return new DummyDosageAPI();
+        }
+
+        @Override
+        public List<String> getDosageFromJson(Path jsonFile) throws IOException {
+            // Return dummy dosage entries based on file name
+            return List.of("dosage_from_" + jsonFile.getFileName());
+        }
+
+    }
+
+    private DosageMarkdown<DummyDosageAPI, String> dosageMarkdown = new DummyMarkdown();
+
+    @Test
+    void testDefaultGetResourcesDir() {
+        Path expected = Path.of("src", "site", "resources", "examples");
+        assertEquals(expected, dosageMarkdown.getResourcesDir(), "Default getResourcesDir should match expected path");
+    }
+
+    @Test
+    void testDefaultLocales() {
+        Locale expected = Locale.ENGLISH;
+        assertTrue(dosageMarkdown.getLocales().contains(expected), "Locales should include English");
+    }
+
+    @Test
+    void testGetOutputDirRoot() {
+        Path folder = Path.of("src", "site", "resources", "examples");
+        Path expected = Path.of("src", "site", "en", "markdown", "examples", "general");
+
+        assertEquals(expected, dosageMarkdown.getOutputDir(Locale.ENGLISH, folder));
+    }
+
+    @Test
+    void testGetOutputDirSimple() {
+        Path folder = Path.of("src", "site", "resources", "examples", "text");
+        Path expected = Path.of("src", "site", "en", "markdown", "examples", "text");
+
+        assertEquals(expected, dosageMarkdown.getOutputDir(Locale.ENGLISH, folder));
+    }
+
+    @Test
+    void testGetOutputDirNested() {
+        Path folder = Path.of("src", "site", "resources", "examples", "text", "complex");
+        Path expected = Path.of("src", "site", "en", "markdown", "examples", "text", "complex");
+
+        assertEquals(expected, dosageMarkdown.getOutputDir(Locale.ENGLISH, folder));
+    }
+}

--- a/common/src/test/java/io/github/jy95/fds/DosageMarkdownTest.java
+++ b/common/src/test/java/io/github/jy95/fds/DosageMarkdownTest.java
@@ -94,6 +94,11 @@ public class DosageMarkdownTest {
             public Path getBaseOutputDir(Locale locale) {
                 return fs.getPath("src", "site", locale.getLanguage(), "markdown", "examples");
             }
+
+            @Override
+            public List<Locale> getLocales() {
+                return List.of(Locale.ENGLISH);
+            }
         }
         var inMemoryMarkdown = new InMemoryMarkdown();
 

--- a/common/src/test/java/io/github/jy95/fds/DosageMarkdownTest.java
+++ b/common/src/test/java/io/github/jy95/fds/DosageMarkdownTest.java
@@ -85,6 +85,38 @@ public class DosageMarkdownTest {
     }
 
     @Test
+    void testDeFaultLocales() {
+        // Step 1: Create a dummy instance of the class
+        var dosageMarkdown = new DummyMarkdown();
+
+        // Step 2: Get the default locales
+        var defaultLocales = dosageMarkdown.getLocales();
+
+        // Step 3: Assert that the default locales are not empty
+        assertFalse(defaultLocales.isEmpty(), "Default locales should not be empty");
+    }
+
+    @Test
+    void testDefaultBaseOutputDir() {
+        // Step 1: Create a dummy instance of the class
+        var dosageMarkdown = new DummyMarkdown();
+        // Step 2: Get the default base output directory
+        var defaultBaseOutputDir = dosageMarkdown.getBaseOutputDir(Locale.ENGLISH);
+        // Step 3: Assert that the default base output directory is not null        
+        assertNotNull(defaultBaseOutputDir, "Default base output directory should not be null");
+    }
+
+    @Test
+    void testDefaultResourcesDir() {
+        // Step 1: Create a dummy instance of the class
+        var dosageMarkdown = new DummyMarkdown();
+        // Step 2: Get the default resources directory
+        var defaultResourcesDir = dosageMarkdown.getResourcesDir();
+        // Step 3: Assert that the default resources directory is not null
+        assertNotNull(defaultResourcesDir, "Default resources directory should not be null");
+    }
+
+    @Test
     void testGenerateMarkdown_realFlowInVirtualFS() throws Exception {
 
         // Step 1: Virtual filesystem setup

--- a/common/src/test/java/io/github/jy95/fds/DosageMarkdownTest.java
+++ b/common/src/test/java/io/github/jy95/fds/DosageMarkdownTest.java
@@ -91,9 +91,8 @@ public class DosageMarkdownTest {
             }
 
             @Override
-            public Path getOutputDir(Locale locale, Path folder) {
-                String outputFolderName = getOutputName(folder);
-                return fs.getPath("src", "site", locale.getLanguage(), "markdown", "examples", outputFolderName);
+            public Path getBaseOutputDir(Locale locale) {
+                return fs.getPath("src", "site", locale.getLanguage(), "markdown", "examples");
             }
         }
         var inMemoryMarkdown = new InMemoryMarkdown();

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,12 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.roastedroot</groupId>
+            <artifactId>zerofs</artifactId>
+            <version>0.0.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <reporting>

--- a/r4/src/main/java/io/github/jy95/fds/r4/utils/DosageMarkdownR4.java
+++ b/r4/src/main/java/io/github/jy95/fds/r4/utils/DosageMarkdownR4.java
@@ -9,6 +9,11 @@ import java.util.Locale;
 import org.hl7.fhir.r4.model.Dosage;
 import org.hl7.fhir.r4.model.MedicationKnowledge;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import io.github.jy95.fds.common.types.DosageMarkdown;
@@ -25,28 +30,64 @@ public class DosageMarkdownR4 implements DosageMarkdown<DosageAPIR4, Dosage> {
     /**
      * The FHIR context for R4.
      */
-    IParser jsonParser = FhirContext.forR4().newJsonParser();
+    private static final IParser JSON_PARSER = FhirContext.forR4().newJsonParser();
 
-    // Template: %s will be replaced by either a single object or an array of objects
-    private static final String TEMPLATE =
-        "{\n" +
-        "  \"resourceType\": \"MedicationKnowledge\",\n" +
-        "  \"status\": \"active\",\n" +
-        "  \"code\": { \"text\": \"dummy\" },\n" +
-        "  \"dosageGuideline\": [\n" +
-        "    {\n" +
-        "      \"dosage\": %s\n" +
-        "    }\n" +
-        "  ]\n" +
-        "}";
+    /**
+     * The ObjectMapper for JSON parsing.
+     */
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    /**
+     * The base JSON template for the MedicationKnowledge resource.
+     */
+    private static final ObjectNode BASE_TEMPLATE = createJsonTemplate();
+
+
+    /**
+     * The JSON parser for parsing dosage data.
+     */
+    private static ObjectNode createJsonTemplate() {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("resourceType", "MedicationKnowledge");
+        root.put("status", "active");
+
+        ObjectNode code = MAPPER.createObjectNode();
+        code.put("text", "dummy");
+        root.set("code", code);
+
+        // Create an empty dosageGuideline array with one object ready for dosage injection
+        ObjectNode guideline = MAPPER.createObjectNode();
+        guideline.set("dosage", MAPPER.createArrayNode());
+
+        ArrayNode guidelineArray = MAPPER.createArrayNode();
+        guidelineArray.add(guideline);
+        root.set("dosageGuideline", guidelineArray);
+
+        return root;
+    }
 
     @Override
     public List<Dosage> getDosageFromJson(Path jsonFile) throws IOException {
-        String dosageJson = Files.readString(jsonFile);
-        String cleanDosageJson = dosageJson.trim();
-        String dosagePart = cleanDosageJson.startsWith("[") ? cleanDosageJson : "[" + cleanDosageJson + "]";
-        String wrappedJson = String.format(TEMPLATE, dosagePart);
-        MedicationKnowledge mk = jsonParser.parseResource(MedicationKnowledge.class, wrappedJson);
+        String dosageJson = Files.readString(jsonFile).trim();
+        JsonNode dosageNode = MAPPER.readTree(dosageJson);
+
+        // Ensure it's an array
+        ArrayNode dosageArray = dosageNode.isArray()
+            ? (ArrayNode) dosageNode
+            : MAPPER.createArrayNode().add(dosageNode);
+
+        // Deep copy the base template
+        ObjectNode workingCopy = BASE_TEMPLATE.deepCopy();
+
+        // Inject into guideline[0].dosage
+        ArrayNode guidelineArray = (ArrayNode) workingCopy.get("dosageGuideline");
+        ObjectNode firstGuideline = (ObjectNode) guidelineArray.get(0);
+        firstGuideline.set("dosage", dosageArray);
+
+        // Convert back to MedicationKnowledge
+        String finalJson = MAPPER.writeValueAsString(workingCopy);
+        MedicationKnowledge mk = JSON_PARSER.parseResource(MedicationKnowledge.class, finalJson);
+
+        // Return the dosage from the first guideline
         return mk.getAdministrationGuidelinesFirstRep().getDosageFirstRep().getDosage();
     }
 

--- a/r4/src/main/java/io/github/jy95/fds/r4/utils/DosageMarkdownR4.java
+++ b/r4/src/main/java/io/github/jy95/fds/r4/utils/DosageMarkdownR4.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 
 import org.hl7.fhir.r4.model.Dosage;
 import org.hl7.fhir.r4.model.MedicationKnowledge;
@@ -12,6 +13,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import io.github.jy95.fds.common.types.DosageMarkdown;
 import io.github.jy95.fds.r4.DosageAPIR4;
+import io.github.jy95.fds.r4.config.FDSConfigR4;
 
 /**
  * An interface for generating Markdown examples of dosage information.
@@ -39,11 +41,6 @@ public class DosageMarkdownR4 implements DosageMarkdown<DosageAPIR4, Dosage> {
         "}";
 
     @Override
-    public DosageAPIR4 getDosageAPI() {
-        return new DosageAPIR4();
-    }
-
-    @Override
     public List<Dosage> getDosageFromJson(Path jsonFile) throws IOException {
         String dosageJson = Files.readString(jsonFile);
         String cleanDosageJson = dosageJson.trim();
@@ -51,6 +48,16 @@ public class DosageMarkdownR4 implements DosageMarkdown<DosageAPIR4, Dosage> {
         String wrappedJson = String.format(TEMPLATE, dosagePart);
         MedicationKnowledge mk = jsonParser.parseResource(MedicationKnowledge.class, wrappedJson);
         return mk.getAdministrationGuidelinesFirstRep().getDosageFirstRep().getDosage();
+    }
+
+    @Override
+    public DosageAPIR4 createDosageAPI(Locale locale) {
+        return new DosageAPIR4(
+            FDSConfigR4
+                .builder()
+                .locale(locale)
+                .build()
+        );
     }
     
 }

--- a/r4/src/main/java/io/github/jy95/fds/r4/utils/DosageMarkdownR4.java
+++ b/r4/src/main/java/io/github/jy95/fds/r4/utils/DosageMarkdownR4.java
@@ -24,6 +24,9 @@ import io.github.jy95.fds.r4.config.FDSConfigR4;
  * An interface for generating Markdown examples of dosage information.
  * Implementations of this interface can read dosage R4 data from JSON files
  * and generate human-readable Markdown documentation in multiple locales.
+ *
+ * @author jy95
+ * @since 1.0.5
  */
 public class DosageMarkdownR4 implements DosageMarkdown<DosageAPIR4, Dosage> {
 
@@ -65,6 +68,7 @@ public class DosageMarkdownR4 implements DosageMarkdown<DosageAPIR4, Dosage> {
         return root;
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Dosage> getDosageFromJson(Path jsonFile) throws IOException {
         String dosageJson = Files.readString(jsonFile).trim();
@@ -91,6 +95,7 @@ public class DosageMarkdownR4 implements DosageMarkdown<DosageAPIR4, Dosage> {
         return mk.getAdministrationGuidelinesFirstRep().getDosageFirstRep().getDosage();
     }
 
+    /** {@inheritDoc} */
     @Override
     public DosageAPIR4 createDosageAPI(Locale locale) {
         return new DosageAPIR4(

--- a/r4/src/main/java/io/github/jy95/fds/r4/utils/DosageMarkdownR4.java
+++ b/r4/src/main/java/io/github/jy95/fds/r4/utils/DosageMarkdownR4.java
@@ -1,0 +1,56 @@
+package io.github.jy95.fds.r4.utils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.hl7.fhir.r4.model.Dosage;
+import org.hl7.fhir.r4.model.MedicationKnowledge;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import io.github.jy95.fds.common.types.DosageMarkdown;
+import io.github.jy95.fds.r4.DosageAPIR4;
+
+/**
+ * An interface for generating Markdown examples of dosage information.
+ * Implementations of this interface can read dosage R4 data from JSON files
+ * and generate human-readable Markdown documentation in multiple locales.
+ */
+public class DosageMarkdownR4 implements DosageMarkdown<DosageAPIR4, Dosage> {
+
+    /**
+     * The FHIR context for R4.
+     */
+    IParser jsonParser = FhirContext.forR4().newJsonParser();
+
+    // Template: %s will be replaced by either a single object or an array of objects
+    private static final String TEMPLATE =
+        "{\n" +
+        "  \"resourceType\": \"MedicationKnowledge\",\n" +
+        "  \"status\": \"active\",\n" +
+        "  \"code\": { \"text\": \"dummy\" },\n" +
+        "  \"dosageGuideline\": [\n" +
+        "    {\n" +
+        "      \"dosage\": %s\n" +
+        "    }\n" +
+        "  ]\n" +
+        "}";
+
+    @Override
+    public DosageAPIR4 getDosageAPI() {
+        return new DosageAPIR4();
+    }
+
+    @Override
+    public List<Dosage> getDosageFromJson(Path jsonFile) throws IOException {
+        String dosageJson = Files.readString(jsonFile);
+        String cleanDosageJson = dosageJson.trim();
+        String dosagePart = cleanDosageJson.startsWith("[") ? cleanDosageJson : "[" + cleanDosageJson + "]";
+        String wrappedJson = String.format(TEMPLATE, dosagePart);
+        MedicationKnowledge mk = jsonParser.parseResource(MedicationKnowledge.class, wrappedJson);
+        return mk.getAdministrationGuidelinesFirstRep().getDosageFirstRep().getDosage();
+    }
+    
+}

--- a/r4/src/test/java/io/github/jy95/fds/r4/DosageMarkdownR4Test.java
+++ b/r4/src/test/java/io/github/jy95/fds/r4/DosageMarkdownR4Test.java
@@ -1,0 +1,73 @@
+package io.github.jy95.fds.r4;
+
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.github.jy95.fds.r4.utils.DosageMarkdownR4;
+import io.roastedroot.zerofs.Configuration;
+import io.roastedroot.zerofs.ZeroFs;
+
+public class DosageMarkdownR4Test {
+
+    private void assertMarkdownFileContent(Path markdownFile, String headerContains, String... contentContains) throws IOException {
+        assertTrue(Files.exists(markdownFile), "Markdown file should exist: " + markdownFile);
+        String content = Files.readString(markdownFile);
+        assertTrue(content.contains("# " + headerContains), "Header should contain: " + headerContains + " in " + markdownFile);
+        for (String expectedContent : contentContains) {
+            assertTrue(content.contains(expectedContent), "Content should contain: " + expectedContent + " in " + markdownFile);
+        }
+    }
+
+    @Test
+    void testGenerateMarkdown_realFlowInVirtualFS() throws Exception {
+        // Step 1: Virtual filesystem setup
+        var fs = ZeroFs.newFileSystem(Configuration.unix());
+        var srcFolder = fs.getPath("src", "site", "resources", "examples");
+        Files.createDirectories(srcFolder);
+
+        // Step 2: Create dummy JSON files
+        var jsonFile1 = srcFolder.resolve("simple.json");
+        String jsonContent = "{\"additionalInstruction\": [\"Instruction 1\"]}";
+        Files.writeString(jsonFile1, jsonContent, StandardCharsets.UTF_8);
+        var jsonFile2 = srcFolder.resolve("complex.json");
+        String jsonContent2 = "[{\"additionalInstruction\": [\"Instruction 1\", \"Instruction 2\"]}]";
+        Files.writeString(jsonFile2, jsonContent2, StandardCharsets.UTF_8);
+
+        // Step 3: Custom subclass only for directory override
+        class InMemoryMarkdown extends DosageMarkdownR4 {
+            @Override
+            public Path getResourcesDir() {
+                return srcFolder;
+            }
+
+            @Override
+            public Path getBaseOutputDir(Locale locale) {
+                return fs.getPath("src", "site", locale.getLanguage(), "markdown", "examples");
+            }
+        }
+        var inMemoryMarkdown = new InMemoryMarkdown();
+
+        // Step 4: Run real logic
+        inMemoryMarkdown.generateMarkdown();
+
+        // Step 5: Assert the output
+        // 5.1 : Check that the locale folder was created
+        var localeFolder = fs.getPath("src", "site", "en", "markdown", "examples");
+        assertTrue(Files.exists(localeFolder), "Locale folder should exist");
+
+        // 5.2 : Check that the output files were created
+        var outputFile = localeFolder.resolve("examples.md");
+
+        // Step 6: Assert the content of the files using the reusable method
+        assertMarkdownFileContent(outputFile, "examples", "Instruction 1");
+        assertMarkdownFileContent(outputFile, "examples",  "Instruction 2");
+        fs.close();
+    }
+}

--- a/r4/src/test/java/io/github/jy95/fds/r4/DosageMarkdownR4Test.java
+++ b/r4/src/test/java/io/github/jy95/fds/r4/DosageMarkdownR4Test.java
@@ -33,10 +33,10 @@ public class DosageMarkdownR4Test {
 
         // Step 2: Create dummy JSON files
         var jsonFile1 = srcFolder.resolve("simple.json");
-        String jsonContent = "{\"additionalInstruction\": [\"Instruction 1\"]}";
+        String jsonContent = "{\"additionalInstruction\": [{\"text\": \"Instruction 1\"}]}";
         Files.writeString(jsonFile1, jsonContent, StandardCharsets.UTF_8);
         var jsonFile2 = srcFolder.resolve("complex.json");
-        String jsonContent2 = "[{\"additionalInstruction\": [\"Instruction 1\", \"Instruction 2\"]}]";
+        String jsonContent2 = "[{\"additionalInstruction\": [{\"text\": \"Instruction 1\"}, {\"text\": \"Instruction 2\"}]}]";
         Files.writeString(jsonFile2, jsonContent2, StandardCharsets.UTF_8);
 
         // Step 3: Custom subclass only for directory override
@@ -66,7 +66,7 @@ public class DosageMarkdownR4Test {
 
         // Step 6: Assert the content of the files using the reusable method
         assertMarkdownFileContent(outputFile, "examples", "Instruction 1");
-        assertMarkdownFileContent(outputFile, "examples",  "Instruction 2");
+        assertMarkdownFileContent(outputFile, "examples",  "Instruction 1 and Instruction 2");
         fs.close();
     }
 }

--- a/r4/src/test/java/io/github/jy95/fds/r4/DosageMarkdownR4Test.java
+++ b/r4/src/test/java/io/github/jy95/fds/r4/DosageMarkdownR4Test.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/r5/src/main/java/io/github/jy95/fds/r5/utils/DosageMarkdownR5.java
+++ b/r5/src/main/java/io/github/jy95/fds/r5/utils/DosageMarkdownR5.java
@@ -40,7 +40,7 @@ public class DosageMarkdownR5 implements DosageMarkdown<DosageAPIR5, Dosage> {
      */
     private static final ObjectMapper MAPPER = new ObjectMapper();
     /**
-     * The base JSON template for the MedicationKnowledge resource.
+     * The base JSON template for the MedicationRequest resource.
      */
     private static final ObjectNode BASE_TEMPLATE = createJsonTemplate();
 
@@ -71,7 +71,7 @@ public class DosageMarkdownR5 implements DosageMarkdown<DosageAPIR5, Dosage> {
         // Inject dosage data into the template
         workingCopy.set("dosageInstruction", dosageArray);
 
-        // Convert back to MedicationKnowledge
+        // Convert back to MedicationRequest
         String finalJson = MAPPER.writeValueAsString(workingCopy);
         MedicationRequest mr = JSON_PARSER.parseResource(MedicationRequest.class, finalJson);
 

--- a/r5/src/main/java/io/github/jy95/fds/r5/utils/DosageMarkdownR5.java
+++ b/r5/src/main/java/io/github/jy95/fds/r5/utils/DosageMarkdownR5.java
@@ -1,0 +1,134 @@
+package io.github.jy95.fds.r5.utils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+import org.hl7.fhir.r5.model.Dosage;
+import org.hl7.fhir.r5.model.MedicationKnowledge;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import io.github.jy95.fds.common.types.DosageMarkdown;
+import io.github.jy95.fds.r5.DosageAPIR5;
+import io.github.jy95.fds.r5.config.FDSConfigR5;
+
+/**
+ * An interface for generating Markdown examples of dosage information.
+ * Implementations of this interface can read dosage R5 data from JSON files
+ * and generate human-readable Markdown documentation in multiple locales.
+ *
+ * @author jy95
+ * @since 1.0.5
+ */
+public class DosageMarkdownR5 implements DosageMarkdown<DosageAPIR5, Dosage> {
+
+    /**
+     * The FHIR context for R5.
+     */
+    private static final IParser JSON_PARSER = FhirContext.forR5().newJsonParser();
+
+    /**
+     * The ObjectMapper for JSON parsing.
+     */
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    /**
+     * The base JSON template for the MedicationKnowledge resource.
+     */
+    private static final ObjectNode BASE_TEMPLATE = createJsonTemplate();
+
+    
+    @Override
+    public DosageAPIR5 createDosageAPI(Locale locale) {
+        return new DosageAPIR5(
+            FDSConfigR5
+                .builder()
+                .locale(locale)
+                .build()
+        );
+    }
+
+    @Override
+    public List<Dosage> getDosageFromJson(Path jsonFile) throws IOException {
+        String dosageJson = Files.readString(jsonFile).trim();
+        JsonNode dosageNode = MAPPER.readTree(dosageJson);
+
+        // Ensure it's an array
+        ArrayNode dosageArray = dosageNode.isArray()
+            ? (ArrayNode) dosageNode
+            : MAPPER.createArrayNode().add(dosageNode);
+
+        // Deep copy the base template
+        ObjectNode workingCopy = BASE_TEMPLATE.deepCopy();
+
+        // Inject dosage JSON into the correct location of the static template
+        ArrayNode dosageList = (ArrayNode)
+            workingCopy
+                .withObject("indicationGuideline")
+                .withArray("dosingGuideline")
+                .get(0)
+                .withArray("dosage")
+                .get(0)
+                .withArray("dosage");
+
+        for (JsonNode dosage : dosageArray) {
+            dosageList.add(dosage);
+        }
+        
+        // Convert back to MedicationKnowledge
+        String finalJson = MAPPER.writeValueAsString(workingCopy);
+        MedicationKnowledge mk = JSON_PARSER.parseResource(MedicationKnowledge.class, finalJson);
+
+        // Return the dosage from the first guideline
+        return mk.getIndicationGuidelineFirstRep().getDosingGuidelineFirstRep().getDosageFirstRep().getDosage();
+    }
+
+    /**
+     * The JSON parser for parsing dosage data.
+     */
+    private static ObjectNode createJsonTemplate() {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("resourceType", "MedicationKnowledge");
+        root.put("status", "active");
+
+        ObjectNode code = MAPPER.createObjectNode();
+        code.put("text", "dummy");
+        root.set("code", code);
+
+        // Create an empty dosingGuideline array with one object ready for dosage injection
+        ObjectNode dosingGuideline = MAPPER.createObjectNode();
+
+        // Add the type attribute
+        ObjectNode type = MAPPER.createObjectNode();
+        ArrayNode codingArray = MAPPER.createArrayNode();
+        ObjectNode coding = MAPPER.createObjectNode();
+        coding.put("system", "http://terminology.hl7.org/CodeSystem/dose-rate-type");
+        coding.put("code", "ordered");
+        codingArray.add(coding);
+        type.set("coding", codingArray);
+        dosingGuideline.set("type", type);
+
+        ArrayNode dosageArray = MAPPER.createArrayNode();
+        ObjectNode dosageInstruction = MAPPER.createObjectNode();
+        dosageInstruction.set("dosage", MAPPER.createArrayNode());
+        dosageArray.add(dosageInstruction);
+        dosingGuideline.set("dosage", dosageArray);
+
+        ArrayNode dosingGuidelineArray = MAPPER.createArrayNode();
+        dosingGuidelineArray.add(dosingGuideline);
+        root.set("indicationGuideline", MAPPER.createArrayNode());
+        ObjectNode indicationGuideline = MAPPER.createObjectNode();
+        indicationGuideline.set("dosingGuideline", dosingGuidelineArray);
+        root.set("indicationGuideline", indicationGuideline);
+
+        return root;
+    }
+    
+}

--- a/r5/src/test/java/io/github/jy95/fds/r5/DosageMarkdownR5Test.java
+++ b/r5/src/test/java/io/github/jy95/fds/r5/DosageMarkdownR5Test.java
@@ -32,10 +32,10 @@ public class DosageMarkdownR5Test {
 
         // Step 2: Create dummy JSON files
         var jsonFile1 = srcFolder.resolve("simple.json");
-        String jsonContent = "{\"additionalInstruction\": [\"Instruction 1\"]}";
+        String jsonContent = "{\"additionalInstruction\": [{\"text\": \"Instruction 1\"}]}";
         Files.writeString(jsonFile1, jsonContent, StandardCharsets.UTF_8);
         var jsonFile2 = srcFolder.resolve("complex.json");
-        String jsonContent2 = "[{\"additionalInstruction\": [\"Instruction 1\", \"Instruction 2\"]}]";
+        String jsonContent2 = "[{\"additionalInstruction\": [{\"text\": \"Instruction 1\"}, {\"text\": \"Instruction 2\"}]}]";
         Files.writeString(jsonFile2, jsonContent2, StandardCharsets.UTF_8);
 
         // Step 3: Custom subclass only for directory override
@@ -65,7 +65,7 @@ public class DosageMarkdownR5Test {
 
         // Step 6: Assert the content of the files using the reusable method
         assertMarkdownFileContent(outputFile, "examples", "Instruction 1");
-        assertMarkdownFileContent(outputFile, "examples",  "Instruction 2");
+        assertMarkdownFileContent(outputFile, "examples",  "Instruction 1 and Instruction 2");
         fs.close();
     }
 

--- a/r5/src/test/java/io/github/jy95/fds/r5/DosageMarkdownR5Test.java
+++ b/r5/src/test/java/io/github/jy95/fds/r5/DosageMarkdownR5Test.java
@@ -1,0 +1,72 @@
+package io.github.jy95.fds.r5;
+
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import io.github.jy95.fds.r5.utils.DosageMarkdownR5;
+import io.roastedroot.zerofs.Configuration;
+import io.roastedroot.zerofs.ZeroFs;
+
+public class DosageMarkdownR5Test {
+    
+    private void assertMarkdownFileContent(Path markdownFile, String headerContains, String... contentContains) throws IOException {
+        assertTrue(Files.exists(markdownFile), "Markdown file should exist: " + markdownFile);
+        String content = Files.readString(markdownFile);
+        assertTrue(content.contains("# " + headerContains), "Header should contain: " + headerContains + " in " + markdownFile);
+        for (String expectedContent : contentContains) {
+            assertTrue(content.contains(expectedContent), "Content should contain: " + expectedContent + " in " + markdownFile);
+        }
+    }
+
+    @Test
+    void testGenerateMarkdown_realFlowInVirtualFS() throws Exception {
+        // Step 1: Virtual filesystem setup
+        var fs = ZeroFs.newFileSystem(Configuration.unix());
+        var srcFolder = fs.getPath("src", "site", "resources", "examples");
+        Files.createDirectories(srcFolder);
+
+        // Step 2: Create dummy JSON files
+        var jsonFile1 = srcFolder.resolve("simple.json");
+        String jsonContent = "{\"additionalInstruction\": [\"Instruction 1\"]}";
+        Files.writeString(jsonFile1, jsonContent, StandardCharsets.UTF_8);
+        var jsonFile2 = srcFolder.resolve("complex.json");
+        String jsonContent2 = "[{\"additionalInstruction\": [\"Instruction 1\", \"Instruction 2\"]}]";
+        Files.writeString(jsonFile2, jsonContent2, StandardCharsets.UTF_8);
+
+        // Step 3: Custom subclass only for directory override
+        class InMemoryMarkdown extends DosageMarkdownR5 {
+            @Override
+            public Path getResourcesDir() {
+                return srcFolder;
+            }
+
+            @Override
+            public Path getBaseOutputDir(Locale locale) {
+                return fs.getPath("src", "site", locale.getLanguage(), "markdown", "examples");
+            }
+        }
+        var inMemoryMarkdown = new InMemoryMarkdown();
+
+        // Step 4: Run real logic
+        inMemoryMarkdown.generateMarkdown();
+
+        // Step 5: Assert the output
+        // 5.1 : Check that the locale folder was created
+        var localeFolder = fs.getPath("src", "site", "en", "markdown", "examples");
+        assertTrue(Files.exists(localeFolder), "Locale folder should exist");
+
+        // 5.2 : Check that the output files were created
+        var outputFile = localeFolder.resolve("examples.md");
+
+        // Step 6: Assert the content of the files using the reusable method
+        assertMarkdownFileContent(outputFile, "examples", "Instruction 1");
+        assertMarkdownFileContent(outputFile, "examples",  "Instruction 2");
+        fs.close();
+    }
+
+}


### PR DESCRIPTION
This PR gives the possibility to generate Markdown to summarize bunch of FHIR Dosage JSON & their human readable text into something clear. Could be useful for the Maven site documentation process in the future ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to generate Markdown documentation from dosage JSON files, supporting multiple languages and structured output.
  - Added support for reading and processing dosage data in FHIR R4 and R5 formats, with localized output.
- **Tests**
  - Added comprehensive tests to validate Markdown generation from dosage data using a virtual filesystem for both R4 and R5 implementations.
  - Included tests to verify error handling during Markdown generation.
  - Added tests for the common dosage markdown interface with dummy implementations.
- **Chores**
  - Added a new test dependency to improve testing capabilities.
- **Documentation**
  - Enhanced Javadoc formatting and added author metadata to time-related formatter classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->