### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/translate_properties.yml
+++ b/.github/workflows/translate_properties.yml
@@ -1,5 +1,9 @@
 name: Translate Properties Files
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/jy95/fds/security/code-scanning/18](https://github.com/jy95/fds/security/code-scanning/18)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, the following permissions are necessary:
- `contents: read` for reading repository contents.
- `pull-requests: write` for creating pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `translate` job. Adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions for the translation automation process to improve access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->